### PR TITLE
set JavaScript questions' text-decoration to none

### DIFF
--- a/assets/css/questions-list-style.css
+++ b/assets/css/questions-list-style.css
@@ -1,0 +1,3 @@
+.questions-list > li > a {
+    text-decoration: none;
+}

--- a/javascript/index.html
+++ b/javascript/index.html
@@ -15,6 +15,7 @@
         </title>
 
         <link rel="shortcut icon" type="image/png" href="../assets/favicon.png"/>
+        <link rel="stylesheet" href="../assets/css/questions-list-style.css">
 
         <meta name="description" content="JavScript interview questions">
     </head>
@@ -48,7 +49,7 @@
             </p>
         </div>
 
-        <ol>
+        <ol class='questions-list'>
             <li>
                 <a href="./answers/q1.html">
                     <h4>


### PR DESCRIPTION
Set the text-decoration of 'a' tags for all Javascript questions to none using CSS.